### PR TITLE
Remove extra points and little refactoring

### DIFF
--- a/src/diamond.js
+++ b/src/diamond.js
@@ -1,4 +1,5 @@
 // Direct variation of `symbolDiamond` from d3-shape.
+import {drawPath} from './drawPath';
 
 var tan30 = Math.sqrt(1 / 3);
 var tan30_2 = tan30 * 2;
@@ -8,12 +9,12 @@ export var diamondAlt = {
     var x = Math.sqrt(size / tan30_2);
     var y = x * tan30;
 
-    context.moveTo(0, -y);
-    context.lineTo(x, 0);
-    context.lineTo(0, y);
-    context.lineTo(-x, 0);
-
-    context.closePath();
+    drawPath(context, [
+      [ 0, -y ],
+      [ x, 0 ],
+      [ 0, y ],
+      [ -x, 0 ]
+    ]);
   }
 };
 
@@ -22,11 +23,11 @@ export var diamondSquare = {
     var w = Math.sqrt(size);
     var d = w / 2 * Math.sqrt(2);
 
-    context.moveTo(0, -d);
-    context.lineTo(d, 0);
-    context.lineTo(0, d);
-    context.lineTo(-d, 0);
-
-    context.closePath();
+    drawPath(context, [
+      [ 0, -d ],
+      [ d, 0 ],
+      [ 0, d ],
+      [ -d, 0 ]
+    ]);
   }
 };

--- a/src/drawPath.js
+++ b/src/drawPath.js
@@ -1,0 +1,11 @@
+export function drawPath(context, points) {
+  points = points.slice(0);
+
+  context.moveTo.apply(context, points.shift());
+
+  while (points.length) {
+      context.lineTo.apply(context, points.shift());
+  }
+
+  context.closePath();
+}

--- a/src/generatePoints.js
+++ b/src/generatePoints.js
@@ -1,0 +1,16 @@
+import {tau} from './math';
+import {rotatePoint} from './rotatePoint';
+
+export function generatePoints(count, R, theta) {
+  var points = [];
+
+  for (var i = 0; i < count; ++i) {
+    var a = tau * i / count;
+    var x = Math.cos(a) * R;
+    var y = Math.sin(a) * R;
+
+    points.push(rotatePoint(x, y, theta));
+  }
+
+  return points;
+}

--- a/src/hexagon.js
+++ b/src/hexagon.js
@@ -1,6 +1,7 @@
 // Hexagon reference: http://mathworld.wolfram.com/Hexagon.html
 import {tau} from './math';
 import {rotatePoint} from './rotatePoint';
+import {drawPath} from './drawPath';
 
 function sideLength(area) {
   var num = 2 * area;
@@ -15,17 +16,17 @@ function drawBuild(theta) {
     var s = sideLength(size);
     var R = s;
 
-    context.moveTo.apply(context, rotatePoint(R, 0, t));
+    var points = [ rotatePoint(R, 0, t) ];
 
     for (var i = 0; i < 6; ++i) {
       var a = tau * i / 6;
       var x = Math.cos(a) * R;
       var y = Math.sin(a) * R;
 
-      context.lineTo.apply(context, rotatePoint(x, y, t));
+      points.push(rotatePoint(x, y, t));
     }
 
-    context.closePath();
+    drawPath(context, points);
   };
 }
 

--- a/src/hexagon.js
+++ b/src/hexagon.js
@@ -1,6 +1,6 @@
 // Hexagon reference: http://mathworld.wolfram.com/Hexagon.html
 import {tau} from './math';
-import {rotatePoint} from './rotatePoint';
+import {generatePoints} from './generatePoints';
 import {drawPath} from './drawPath';
 
 function sideLength(area) {
@@ -16,17 +16,7 @@ function drawBuild(theta) {
     var s = sideLength(size);
     var R = s;
 
-    var points = [];
-
-    for (var i = 0; i < 6; ++i) {
-      var a = tau * i / 6;
-      var x = Math.cos(a) * R;
-      var y = Math.sin(a) * R;
-
-      points.push(rotatePoint(x, y, t));
-    }
-
-    drawPath(context, points);
+    drawPath(context, generatePoints(6, R, t));
   };
 }
 

--- a/src/hexagon.js
+++ b/src/hexagon.js
@@ -16,7 +16,7 @@ function drawBuild(theta) {
     var s = sideLength(size);
     var R = s;
 
-    var points = [ rotatePoint(R, 0, t) ];
+    var points = [];
 
     for (var i = 0; i < 6; ++i) {
       var a = tau * i / 6;

--- a/src/octagon.js
+++ b/src/octagon.js
@@ -1,6 +1,7 @@
 // Octagon reference: http://mathworld.wolfram.com/Octagon.html
 import {tau} from './math';
 import {rotatePoint} from './rotatePoint';
+import {drawPath} from './drawPath';
 
 var circumradiusCoeff = 1/2 * Math.sqrt(4 + 2 * Math.sqrt(2)); // ~ 1.3065629648763766
 
@@ -19,17 +20,17 @@ function drawBuild(theta) {
     var s = sideLength(size);
     var R = circumradius(s);
 
-    context.moveTo.apply(context, rotatePoint(R, 0, t));
+    var points = [ rotatePoint(R, 0, t) ];
 
     for (var i = 0; i < 8; ++i) {
       var a = tau * i / 8;
       var x = Math.cos(a) * R;
       var y = Math.sin(a) * R;
 
-      context.lineTo.apply(context, rotatePoint(x, y, t));
+      points.push(rotatePoint(x, y, t));
     }
 
-    context.closePath();
+    drawPath(context, points);
   };
 }
 

--- a/src/octagon.js
+++ b/src/octagon.js
@@ -20,7 +20,7 @@ function drawBuild(theta) {
     var s = sideLength(size);
     var R = circumradius(s);
 
-    var points = [ rotatePoint(R, 0, t) ];
+    var points = [];
 
     for (var i = 0; i < 8; ++i) {
       var a = tau * i / 8;

--- a/src/octagon.js
+++ b/src/octagon.js
@@ -1,6 +1,6 @@
 // Octagon reference: http://mathworld.wolfram.com/Octagon.html
 import {tau} from './math';
-import {rotatePoint} from './rotatePoint';
+import {generatePoints} from './generatePoints';
 import {drawPath} from './drawPath';
 
 var circumradiusCoeff = 1/2 * Math.sqrt(4 + 2 * Math.sqrt(2)); // ~ 1.3065629648763766
@@ -20,17 +20,7 @@ function drawBuild(theta) {
     var s = sideLength(size);
     var R = circumradius(s);
 
-    var points = [];
-
-    for (var i = 0; i < 8; ++i) {
-      var a = tau * i / 8;
-      var x = Math.cos(a) * R;
-      var y = Math.sin(a) * R;
-
-      points.push(rotatePoint(x, y, t));
-    }
-
-    drawPath(context, points);
+    drawPath(context, generatePoints(8, R, t));
   };
 }
 

--- a/src/pentagon.js
+++ b/src/pentagon.js
@@ -1,6 +1,6 @@
 // Pentagon reference: http://mathworld.wolfram.com/Pentagon.html
 import {tau} from './math';
-import {rotatePoint} from './rotatePoint';
+import {generatePoints} from './generatePoints';
 import {drawPath} from './drawPath';
 
 var circumradiusCoeff = 1/10 * Math.sqrt(50 + 10 * Math.sqrt(5)); // ~ 0.85065080835204
@@ -20,16 +20,6 @@ export var pentagon = {
     var R = circumradius(s);
     var theta = -tau / 4; // Rotate 1/4 turn back so the shape is oriented with a point upward.
 
-    var points = [];
-
-    for (var i = 0; i < 5; ++i) {
-      var a = tau * i / 5;
-      var x = Math.cos(a) * R;
-      var y = Math.sin(a) * R;
-
-      points.push(rotatePoint(x, y, theta));
-    }
-
-    drawPath(context, points);
+    drawPath(context, generatePoints(5, R, theta));
   }
 };

--- a/src/pentagon.js
+++ b/src/pentagon.js
@@ -20,7 +20,7 @@ export var pentagon = {
     var R = circumradius(s);
     var theta = -tau / 4; // Rotate 1/4 turn back so the shape is oriented with a point upward.
 
-    var points = [ rotatePoint(R, 0, theta) ];
+    var points = [];
 
     for (var i = 0; i < 5; ++i) {
       var a = tau * i / 5;

--- a/src/pentagon.js
+++ b/src/pentagon.js
@@ -1,6 +1,7 @@
 // Pentagon reference: http://mathworld.wolfram.com/Pentagon.html
 import {tau} from './math';
 import {rotatePoint} from './rotatePoint';
+import {drawPath} from './drawPath';
 
 var circumradiusCoeff = 1/10 * Math.sqrt(50 + 10 * Math.sqrt(5)); // ~ 0.85065080835204
 
@@ -19,16 +20,16 @@ export var pentagon = {
     var R = circumradius(s);
     var theta = -tau / 4; // Rotate 1/4 turn back so the shape is oriented with a point upward.
 
-    context.moveTo.apply(context, rotatePoint(R, 0, theta));
+    var points = [ rotatePoint(R, 0, theta) ];
 
     for (var i = 0; i < 5; ++i) {
       var a = tau * i / 5;
       var x = Math.cos(a) * R;
       var y = Math.sin(a) * R;
 
-      context.lineTo.apply(context, rotatePoint(x, y, theta));
+      points.push(rotatePoint(x, y, theta));
     }
 
-    context.closePath();
+    drawPath(context, points);
   }
 };

--- a/src/triangle.js
+++ b/src/triangle.js
@@ -1,32 +1,37 @@
 // Direct variations of `symbolTriangle` from d3-shape.
+import {drawPath} from './drawPath';
+
 var sqrt3 = Math.sqrt(3);
 
 export var triangleDown = {
   draw: function(context, size) {
     var y = -Math.sqrt(size / (sqrt3 * 3));
-    context.moveTo(0, -y * 2);
-    context.lineTo(-sqrt3 * y, y);
-    context.lineTo(sqrt3 * y, y);
-    context.closePath();
+    drawPath(context, [
+      [ 0, -y * 2 ],
+      [ -sqrt3 * y, y ],
+      [ sqrt3 * y, y ]
+    ]);
   }
 };
 
 export var triangleLeft = {
   draw: function(context, size) {
     var x = -Math.sqrt(size / (sqrt3 * 3));
-    context.moveTo(x * 2, 0);
-    context.lineTo(-x, -sqrt3 * x);
-    context.lineTo(-x, sqrt3 * x);
-    context.closePath();
+    drawPath(context, [
+      [ x * 2, 0 ],
+      [ -x, -sqrt3 * x ],
+      [ -x, sqrt3 * x ]
+    ]);
   }
 };
 
 export var triangleRight = {
   draw: function(context, size) {
     var x = -Math.sqrt(size / (sqrt3 * 3));
-    context.moveTo(-x * 2, 0);
-    context.lineTo(x, -sqrt3 * x);
-    context.lineTo(x, sqrt3 * x);
-    context.closePath();
+    drawPath(context, [
+      [ -x * 2, 0 ],
+      [ x, -sqrt3 * x ],
+      [ x, sqrt3 * x ]
+    ]);
   }
 };

--- a/src/x.js
+++ b/src/x.js
@@ -1,6 +1,7 @@
 // Direct variation of `symbolCross` from d3-shape.
 import {tau} from './math';
 import {rotatePoint} from './rotatePoint';
+import {drawPath} from './drawPath';
 
 export var x = {
   draw: function(context, size) {
@@ -9,6 +10,7 @@ export var x = {
 
     // Use the same construction points as `symbolCross` and rotate 1/8 turn.
     var points = [
+      rotatePoint(-3 * r, r, theta),
       rotatePoint(-3 * r, -r, theta),
       rotatePoint(-r, -r, theta),
       rotatePoint(-r, -3 * r, theta),
@@ -19,16 +21,9 @@ export var x = {
       rotatePoint(r, r, theta),
       rotatePoint(r, 3 * r, theta),
       rotatePoint(-r, 3 * r, theta),
-      rotatePoint(-r, r, theta),
-      rotatePoint(-3 * r, r, theta)
+      rotatePoint(-r, r, theta)
     ];
 
-    context.moveTo.apply(context, points.pop());
-    
-    for (var i = 0; i < points.length; i++) {
-      context.lineTo.apply(context, points[i]);
-    }
-
-    context.closePath();
+    drawPath(context, points);
   }
 };

--- a/test/symbol-test.js
+++ b/test/symbol-test.js
@@ -48,8 +48,8 @@ tape("symbol.type(symbolHexagon) generates a polygon with the specified size", f
 
 tape("symbol.type(symbolHexagon) generates the expected path", function(test) {
   var s = shape.symbol().type(extra.symbolHexagon).size(function(d) { return d; });
-  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0L0,0Z");
-  test.pathEqual(s(10), "M1.699044,0.980944L1.699044,0.980944L0,1.961887L-1.699044,0.980944L-1.699044,-0.980944L0,-1.961887L1.699044,-0.980944Z");
+  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0Z");
+  test.pathEqual(s(10), "M1.699044,0.980944L0,1.961887L-1.699044,0.980944L-1.699044,-0.980944L0,-1.961887L1.699044,-0.980944Z");
   test.end();
 });
 
@@ -64,8 +64,8 @@ tape("symbol.type(symbolHexagonAlt) generates a polygon with the specified size"
 
 tape("symbol.type(symbolHexagonAlt) generates the expected path", function(test) {
   var s = shape.symbol().type(extra.symbolHexagonAlt).size(function(d) { return d; });
-  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0L0,0Z");
-  test.pathEqual(s(10), "M1.961887,0L1.961887,0L0.980944,1.699044L-0.980944,1.699044L-1.961887,0L-0.980944,-1.699044L0.980944,-1.699044Z");
+  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0Z");
+  test.pathEqual(s(10), "M1.961887,0L0.980944,1.699044L-0.980944,1.699044L-1.961887,0L-0.980944,-1.699044L0.980944,-1.699044Z");
   test.end();
 });
 
@@ -80,8 +80,8 @@ tape("symbol.type(symbolOctagon) generates a polygon with the specified size", f
 
 tape("symbol.type(symbolOctagon) generates the expected path", function(test) {
   var s = shape.symbol().type(extra.symbolOctagon).size(function(d) { return d; });
-  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z");
-  test.pathEqual(s(10), "M1.880302,0L1.880302,0L1.329574,1.329574L0,1.880302L-1.329574,1.329574L-1.880302,0L-1.329574,-1.329574L0,-1.880302L1.329574,-1.329574Z");
+  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z");
+  test.pathEqual(s(10), "M1.880302,0L1.329574,1.329574L0,1.880302L-1.329574,1.329574L-1.880302,0L-1.329574,-1.329574L0,-1.880302L1.329574,-1.329574Z");
   test.end();
 });
 
@@ -96,8 +96,8 @@ tape("symbol.type(symbolOctagonAlt) generates a polygon with the specified size"
 
 tape("symbol.type(symbolOctagonAlt) generates the expected path", function(test) {
   var s = shape.symbol().type(extra.symbolOctagonAlt).size(function(d) { return d; });
-  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z");
-  test.pathEqual(s(10), "M1.737172,0.719560L1.737172,0.719560L0.719560,1.737172L-0.719560,1.737172L-1.737172,0.719560L-1.737172,-0.719560L-0.719560,-1.737172L0.719560,-1.737172L1.737172,-0.719560Z");
+  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z");
+  test.pathEqual(s(10), "M1.737172,0.719560L0.719560,1.737172L-0.719560,1.737172L-1.737172,0.719560L-1.737172,-0.719560L-0.719560,-1.737172L0.719560,-1.737172L1.737172,-0.719560Z");
   test.end();
 });
 
@@ -112,8 +112,8 @@ tape("symbol.type(symbolPentagon) generates a polygon with the specified size", 
 
 tape("symbol.type(symbolPentagon) generates the expected path", function(test) {
   var s = shape.symbol().type(extra.symbolPentagon).size(function(d) { return d; });
-  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0L0,0Z");
-  test.pathEqual(s(10), "M0,-2.050817L0,-2.050817L1.950443,-0.633737L1.205440,1.659146L-1.205440,1.659146L-1.950443,-0.633737Z");
+  test.pathEqual(s(0), "M0,0L0,0L0,0L0,0L0,0Z");
+  test.pathEqual(s(10), "M0,-2.050817L1.950443,-0.633737L1.205440,1.659146L-1.205440,1.659146L-1.950443,-0.633737Z");
   test.end();
 });
 


### PR DESCRIPTION
<img width="420" alt="default" src="https://cloud.githubusercontent.com/assets/529247/25559045/0b06a5c4-2d3c-11e7-998f-5225f6a9f0ef.png">

In some symbols first point was duplicated. I fixed it. I also created a function `drawPath` to encapsulate drawing methods `lineTo`, `moveTo` and `closePath`. Now drawing is more declarative:

```js
drawPath(context, [
  [ 0, -y * 2 ],
  [ -sqrt3 * y, y ],
  [ sqrt3 * y, y ]
]);
```

And move points-generating for-loops to another function `generatePoints`. Now instead of

```js
for (var i = 0; i < 8; ++i) {
  var a = tau * i / 8;
  var x = Math.cos(a) * R;
  var y = Math.sin(a) * R;

  ... rotatePoint(x, y, theta);
}
```

you may just write:

```js
generatePoints(8, R, theta);
```

It is also reduces size of minified script a bit:

```bash
# in master branch
wc -c build/d3-symbol-extra.min.js
2465 build/d3-symbol-extra.min.js

# in this branch
wc -c build/d3-symbol-extra.min.js
2037 build/d3-symbol-extra.min.js
```

It is about 17% :)